### PR TITLE
Sort returned list of nodes for easier access

### DIFF
--- a/src/ExamplePanel.tsx
+++ b/src/ExamplePanel.tsx
@@ -115,7 +115,7 @@ function ExamplePanel({ context }: { context: PanelExtensionContext }): JSX.Elem
     setStatus("retreiving nodes...")
     context.callService?.("/rosapi/nodes", {})
     .then((_values: unknown) =>{ 
-      setNodeList((_values as any).nodes as string[]);
+      setNodeList(((_values as any).nodes as string[]).sort());
       setStatus("nodes retreived");  
     })
     .catch((_error: Error) => { setStatus(_error.toString()); });


### PR DESCRIPTION
This simply makes the list of nodes alphabetically ordered, which makes navigating in the GUI easier.