### PR TITLE
Send param request complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # param_ext version history
 
+## 0.0.03
+
+- Fix issue with empty parameters
+
+## 0.0.2
+
+- Alphabetize nodes
+
 ## 0.0.1
 
 - Alpha testing

--- a/README.md
+++ b/README.md
@@ -2,10 +2,17 @@
 
 ## _A Foxglove Studio Extension_
 
-The **ROS2 Parameters Extension** provides parameter functionality for all your ROS2 nodes including: 
+The **ROS2 Parameters Extension** provides parameter functionality for all your ROS2 nodes including:
 
 - **View** a node's parameter names, types, and values in a table format
 - **Set** new parameter values for all types of parameters on a node
 - **Load** a previous configuration from a .yml file stored on your computer
 
-Currently only works with a rosbridge connection
+This plugin relies on the `/rosapi/nodes` service to be available on the robot in order to build a list of running nodes.
+This can either be done by making sure [rosbridge_server](https://github.com/RobotWebTools/rosbridge_suite/blob/ros2/rosbridge_server/launch/rosbridge_websocket_launch.xml) is running:
+
+```ros2 launch rosbridge_server rosbridge_websocket_launch.xml```
+
+or solely the [rosapi node](https://github.com/RobotWebTools/rosbridge_suite/blob/ros2/rosapi/scripts/rosapi_node):
+
+```ros2 run rosapi rosapi_node```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Interact with Parameters in ROS2",
   "publisher": "Daniel Clapp",
   "homepage": "https://github.com/danclapp4/ros2-parameter-extension",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "license": "MIT",
   "main": "./dist/extension.js",
   "keywords": [],

--- a/src/ExamplePanel.tsx
+++ b/src/ExamplePanel.tsx
@@ -115,7 +115,7 @@ function ExamplePanel({ context }: { context: PanelExtensionContext }): JSX.Elem
     setStatus("retreiving nodes...")
     context.callService?.("/rosapi/nodes", {})
     .then((_values: unknown) =>{ 
-      setNodeList((_values as any).nodes as string[]);
+      setNodeList(((_values as any).nodes as string[]).sort());
       setStatus("nodes retreived");  
     })
     .catch((_error: Error) => { setStatus(_error.toString()); });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { ExtensionContext } from "@foxglove/studio";
 import { initParamsPanel } from "./ExamplePanel";
 
 export function activate(extensionContext: ExtensionContext) {
-  extensionContext.registerPanel({ name: "Custom Parameters Extenstion", initPanel: initParamsPanel });
+  extensionContext.registerPanel({ name: "Custom Parameters Extension", initPanel: initParamsPanel });
 }
 
 


### PR DESCRIPTION
This implements the suggestion from here: https://github.com/foxglove/ros-foxglove-bridge/issues/333 where a `/set_parameters` service request should always contain the complete request, not only the changed parameter.

If not done this way, a request with multiple parameters will crash the targeted node.